### PR TITLE
feat: Add summarize_presentation which will allow Agents to summarize…

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,4 +113,18 @@ The server exposes the following tools via the Model Context Protocol:
         *   `pageObjectId` (string, required): The object ID of the page (slide) to retrieve.
     *   **Output:** JSON object representing the page details.
 
+*   **`summarize_presentation`**: Extracts and formats all text content from a presentation for easier summarization.
+    *   **Input:**
+        *   `presentationId` (string, required): The ID of the presentation to summarize.
+        *   `include_notes` (boolean, optional): Whether to include speaker notes in the summary. Defaults to false.
+    *   **Output:** JSON object containing:
+        *   `title`: The presentation's title
+        *   `slideCount`: Total number of slides
+        *   `lastModified`: Revision information
+        *   `slides`: Array of slide objects containing:
+            *   `slideNumber`: Position in presentation
+            *   `slideId`: Object ID of the slide
+            *   `content`: All text extracted from the slide
+            *   `notes`: Speaker notes (if requested and available)
+
 *(More tools can be added by extending `src/index.ts`)*


### PR DESCRIPTION
# Add Presentation Summarization Tool

## Description
This MR adds a new `summarize_presentation` tool that enables easy extraction of textual content from Google Slides presentations. The tool traverses all slides in a presentation and extracts text from various elements including shapes, text boxes, and tables.

## Features
- Extracts text content from all slides in a structured JSON format
- Optional inclusion of speaker notes with the `include_notes` parameter
- Returns a clean, hierarchical structure of the presentation's content
- Provides slide numbers and IDs for reference

## Benefits
- Allows LLMs to efficiently understand presentation content without processing complex slide structures
- Enables presentation summarization and content analysis
- Makes it easier to identify and suggest presentation improvements
- Helps with content extraction for archiving or repurposing

## Implementation Details
- Added tool definition to exposed MCP tools
- Implemented handler method with comprehensive text extraction logic
- Updated README with detailed documentation of the new tool
- Maintains backward compatibility with existing tools